### PR TITLE
Changed secondary color to match primaryColor

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,7 +7,7 @@ module.exports = {
     logoUrl:
       'https://raw.githubusercontent.com/MetaMask/brand-resources/master/SVG/metamask-fox.svg',
     primaryColor: '#3f51b5', // material-ui primary color
-    secondaryColor: '#f50057', // material-ui secondary color
+    secondaryColor: '#3f51b5', // material-ui secondary color
     author: '',
     menuLinks: [
       {


### PR DESCRIPTION
Changing this makes the UI more consistent, and doesn't put any red where we aren't expecting it like responses.


regular response
<img width="1244" alt="image" src="https://user-images.githubusercontent.com/364566/192562705-94a49183-2421-47e6-a82f-2dbcb0fe8527.png">


and heres what an error looks like:

<img width="1238" alt="image" src="https://user-images.githubusercontent.com/364566/192562813-26ffb185-a8d6-42f0-bc28-6b7dfcbbaac1.png">
